### PR TITLE
Fix `kbt.rb` to be installed correctly

### DIFF
--- a/Formula/kbt.rb
+++ b/Formula/kbt.rb
@@ -1,14 +1,14 @@
 class Kbt < Formula
-    desc "Keyboard tester in terminal"
-    homepage "https://github.com/bloznelis/kbt"
-    url "https://github.com/bloznelis/kbt/archive/1.2.3.tar.gz"
-    sha256 "7c74986c28a29a89609176a59e234ef9fd724a20d3dc904853794bd88a60112e"
-    version "1.2.3"
-    depends_on "rust"
-    license "MIT"
+  desc "Keyboard tester in terminal"
+  homepage "https://github.com/bloznelis/kbt"
+  url "https://github.com/bloznelis/kbt/archive/1.2.3.tar.gz"
+  version "1.2.3"
+  sha256 "7c74986c28a29a89609176a59e234ef9fd724a20d3dc904853794bd88a60112e"
+  license "MIT"
+  depends_on "rust"
 
-    def install
-        system "make", "build", "VERSION=#{version}"
-        bin.install "target/release/kbt"
-    end
+  def install
+    system "make", "build", "VERSION=#{version}"
+    bin.install "target/release/kbt"
+  end
 end

--- a/Formula/kbt.rb
+++ b/Formula/kbt.rb
@@ -1,4 +1,4 @@
-class Typioca < Formula
+class Kbt < Formula
     desc "Keyboard tester in terminal"
     homepage "https://github.com/bloznelis/kbt"
     url "https://github.com/bloznelis/kbt/archive/1.2.3.tar.gz"


### PR DESCRIPTION
Because the class name in `kbt.rb` is `Typioca`, change it to `Kbt`.
Also, refactor the file with `brew style`.